### PR TITLE
Fix: use NumberInput instead of TouchSpin

### DIFF
--- a/client/Elements/Components/Common/SizeTimeFormGroup/SizeTimeFormGroup.patternfly.tsx
+++ b/client/Elements/Components/Common/SizeTimeFormGroup/SizeTimeFormGroup.patternfly.tsx
@@ -3,11 +3,19 @@
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 
-import { Flex, FlexItem, Touchspin, TouchspinProps } from '@patternfly/react-core';
+import {
+  Flex,
+  FlexItem,
+  NumberInput,
+  NumberInputProps,
+} from '@patternfly/react-core';
 import React from 'react';
-import { DropdownWithToggle, IDropdownOption } from '../DropdownWithToggle.patternfly';
+import {
+  DropdownWithToggle,
+  IDropdownOption,
+} from '../DropdownWithToggle.patternfly';
 
-export interface SizeTimeFormGroup extends TouchspinProps, TouchspinProps {
+export interface SizeTimeFormGroup extends NumberInputProps {
   /** id of dropdown element */
   id: string;
   /** id of dropdown toggle button */
@@ -38,9 +46,8 @@ export const SizeTimeFormGroup: React.FC<SizeTimeFormGroup> = ({
   value,
   plusBtnProps,
   minusBtnProps,
-  type
+  type,
 }) => {
-
   const timeUnits: IDropdownOption[] = [
     { key: 'millisecond', value: 'millisecond', isDisabled: false },
     { key: 'second', value: 'second', isDisabled: false },
@@ -58,17 +65,20 @@ export const SizeTimeFormGroup: React.FC<SizeTimeFormGroup> = ({
   ];
 
   const getItemsForType = (type: string) => {
-    switch(type){
-    case "time": return timeUnits;
-    case "memory": return memoryUnits;
-    default: return [];
+    switch (type) {
+      case 'time':
+        return timeUnits;
+      case 'memory':
+        return memoryUnits;
+      default:
+        return [];
     }
   };
 
   return (
     <Flex>
       <FlexItem grow={{ default: 'grow' }}>
-        <Touchspin
+        <NumberInput
           inputName={inputName}
           onChange={onChange}
           onPlus={onPlus}

--- a/client/Elements/Components/CreateTopic/CleanupSection.patternfly.tsx
+++ b/client/Elements/Components/CreateTopic/CleanupSection.patternfly.tsx
@@ -10,7 +10,7 @@ import {
   Form,
   TextContent,
   TextVariants,
-  Touchspin,
+  NumberInput,
   Text,
 } from '@patternfly/react-core';
 import { FormGroupWithPopover } from '../Common/FormGroupWithPopover/FormGroupWithPopover.patternfly';
@@ -98,7 +98,7 @@ export const CleanupSection: React.FC = () => {
           labelBody={t('createTopic.minRatioLabelBody')}
           buttonAriaLabel='More info for minimum cleanable ratio field'
         >
-          <Touchspin
+          <NumberInput
             inputName='min-ratio'
             onChange={handleTouchSpinInputChange}
             onPlus={handleTouchSpinPlus}

--- a/client/Elements/Components/CreateTopic/CoreConfiguration.patternfly.tsx
+++ b/client/Elements/Components/CreateTopic/CoreConfiguration.patternfly.tsx
@@ -11,7 +11,7 @@ import {
   TextInput,
   TextVariants,
   Title,
-  Touchspin,
+  NumberInput,
 } from '@patternfly/react-core';
 import React from 'react';
 import { FormGroupWithPopover } from '../Common/FormGroupWithPopover/FormGroupWithPopover.patternfly';
@@ -98,7 +98,7 @@ const CoreConfiguration: React.FC = () => {
           labelBody={t('createTopic.partitionsLabelBody')}
           buttonAriaLabel='More info for partitions field'
         >
-          <Touchspin
+          <NumberInput
             id='create-topic-partitions'
             inputName='partitions'
             onChange={handleTouchSpinInputChange}
@@ -116,7 +116,7 @@ const CoreConfiguration: React.FC = () => {
           labelBody={t('createTopic.replicasLabelBody')}
           buttonAriaLabel='More info for replicas field'
         >
-          <Touchspin
+          <NumberInput
             inputName='replicas'
             onChange={handleTouchSpinInputChange}
             onPlus={handleTouchSpinPlus}
@@ -133,7 +133,7 @@ const CoreConfiguration: React.FC = () => {
           labelBody={t('createTopic.inSyncReplicasLabelBody')}
           buttonAriaLabel='More info for minimum in-sync replicas field'
         >
-          <Touchspin
+          <NumberInput
             id='insyncreplicas'
             inputName='min-in-sync-replicas'
             onChange={handleTouchSpinInputChange}

--- a/client/Elements/Components/CreateTopic/CreateTopicWizard.patternfly.css
+++ b/client/Elements/Components/CreateTopic/CreateTopicWizard.patternfly.css
@@ -44,7 +44,7 @@
   text-transform: uppercase;
 }
 
-.pf-c-touchspin {
+.pf-c-number-input {
   display: block;
 }
 


### PR DESCRIPTION
The build was failing after patternfly update as TouchSpin has been renamed to NumberInput.

Update to #41 

Signed-off-by: Ramakrishna Pattnaik <rkpattnaik780@gmail.com>